### PR TITLE
fix: Handle MCP initialize method

### DIFF
--- a/server.py
+++ b/server.py
@@ -61,7 +61,9 @@ def main():
             log("Received request", request)
 
             response = None
-            if request.get("method") == "list_tools":
+            if request.get("method") == "initialize":
+                response = handle_initialize(request)
+            elif request.get("method") == "list_tools":
                 response = handle_list_tools(request)
             elif request.get("method") == "call_tool":
                 response = handle_call_tool(request)
@@ -100,6 +102,24 @@ def write_response(response):
         log("Sending response", response)
         print(response_str, file=sys.stdout)
         sys.stdout.flush()
+
+def handle_initialize(request):
+    """Handles the initialize request."""
+    log("Handling initialize request")
+    response = {
+        "jsonrpc": "2.0",
+        "id": request.get("id"),
+        "result": {
+            "serverInfo": {
+                "name": "ai-peer-review-py",
+                "version": "1.0.0",
+            },
+            "capabilities": {
+                "tools": {}
+            }
+        }
+    }
+    return response
 
 def handle_list_tools(request):
     """Handles the list_tools request."""


### PR DESCRIPTION
This commit fixes a bug where the Python server would fail to start because it did not handle the `initialize` method sent by the MCP client (e.g., LMStudio).

The Node.js SDK handled this method implicitly, but the manual Python implementation required an explicit handler.

This change adds a handler for the `initialize` method, allowing the server to correctly establish a connection with the client.