### PR TITLE
fix: Add protocolVersion to initialize response

### DIFF
--- a/server.py
+++ b/server.py
@@ -110,6 +110,7 @@ def handle_initialize(request):
         "jsonrpc": "2.0",
         "id": request.get("id"),
         "result": {
+            "protocolVersion": "2025-06-18",
             "serverInfo": {
                 "name": "ai-peer-review-py",
                 "version": "1.0.0",


### PR DESCRIPTION
This commit fixes a bug where the server's `initialize` response was missing the required `protocolVersion` field, causing a ZodError in the LMStudio MCP bridge.

The `protocolVersion` is now included in the response, matching the version sent by you.